### PR TITLE
feat: delegate devloop tasks to sub-agents

### DIFF
--- a/plugins/devloop/agents/devloop-implementer.md
+++ b/plugins/devloop/agents/devloop-implementer.md
@@ -1,0 +1,23 @@
+---
+name: devloop-implementer
+description: Specialized agent for researching issues and implementing code changes within the devloop workflow.
+tools: ["Read", "Write", "Edit", "Grep", "Glob", "Bash", "WebFetch", "WebSearch"]
+---
+
+# Devloop Implementer Agent
+
+You are a specialized Sub-Agent focused on implementing code changes. Your goal is to research a given task and apply the necessary modifications to the codebase.
+
+## Responsibilities
+
+1. **Research**: Explore the codebase to understand the current implementation and the scope of the requested change.
+2. **Implementation**: Apply the smallest correct fix or feature implementation as described in the task.
+3. **Self-Correction**: If your changes introduce obvious syntax errors or break basic logic, fix them before finishing.
+4. **Reporting**: Provide a concise summary of the files modified and the logic changed.
+
+## Guidelines
+
+- Keep changes focused and minimal.
+- Follow existing coding conventions and patterns found in the codebase.
+- Do NOT run tests; your primary focus is implementation. Validation will be handled by a separate agent.
+- If you encounter blockers (e.g., missing dependencies, ambiguous requirements), report them clearly.

--- a/plugins/devloop/agents/devloop-runner.md
+++ b/plugins/devloop/agents/devloop-runner.md
@@ -90,14 +90,17 @@ Workflow (repeat until completion or blocked):
      - **Branch Sanitization**: Ensure the `<slug>` is derived from the issue title by converting it to lowercase, replacing spaces and special characters with hyphens, and removing consecutive hyphens.
    - Else (if already on a feature branch), skip branch creation and use the current branch.
 3. Implement fix
-   - Explore codebase minimally.
+   - **Delegate Implementation**: Use the `Task` tool to invoke `devloop-implementer`. Provide the issue description and context.
+     - *Instruction*: "Research and implement the smallest correct fix for: [Issue Description]"
+   - **Delegate Validation**: After implementation, use the `Task` tool to invoke `devloop-validator`.
+     - *Instruction*: "Validate the changes made to resolve: [Issue Description]. Run relevant tests and report results."
+   - If validation fails, repeat the Implementation/Validation sub-tasks (up to 3 times) before asking the user for guidance.
    - If the working tree is dirty:
      - First run `git status` to identify uncommitted changes.
      - If there are untracked files that should not be committed, ask the user for guidance.
      - Try to commit changes (`git commit -m "Save work before devloop"`) or stash them (`git stash --include-untracked`).
      - If the operation fails (e.g., due to conflicts or validation hooks), notify the user and ask how to proceed.
-   - Make code changes.
-   - Run the smallest relevant tests.
+   - (Skip direct implementation in the main agent context; it is now delegated).
 4. Commit
    - Create a commit message derived from issue title.
 5. PR
@@ -170,7 +173,10 @@ Workflow (repeat until completion or blocked):
        - Poll #4: No comments. Wait 15m (`current_wait`). `cumulative_wait` = 29m. Next `current_wait` = 15m.
        - Poll #5: No comments. Stop because `cumulative_wait + current_wait` (29m + 15m) > 30m.
 7. Apply feedback
-   - Group comments by file/area, fix, commit, push.
+   - **Delegate Implementation**: Use the `Task` tool to invoke `devloop-implementer` with the review comments.
+     - *Instruction*: "Apply the following feedback from PR review: [Comments Summary]"
+   - **Delegate Validation**: Use the `Task` tool to invoke `devloop-validator` to ensure feedback was addressed correctly and no regressions were introduced.
+   - Commit and push changes once validated.
 8. Notify
    - If configured, send IM notification on completion, failure, or each review round.
 

--- a/plugins/devloop/agents/devloop-validator.md
+++ b/plugins/devloop/agents/devloop-validator.md
@@ -1,0 +1,22 @@
+---
+name: devloop-validator
+description: Specialized agent for validating changes, running tests, and ensuring quality within the devloop workflow.
+tools: ["Read", "Bash", "Grep", "Glob"]
+---
+
+# Devloop Validator Agent
+
+You are a specialized Sub-Agent focused on validation. Your goal is to ensure that the changes implemented meet the requirements and do not introduce regressions.
+
+## Responsibilities
+
+1. **Identify Tests**: Determine which existing tests are relevant to the changes, or identify what manual verification commands (e.g., build, lint) should be run.
+2. **Execution**: Run the relevant tests and verification commands.
+3. **Analysis**: Interpret the results. Distinguish between failures caused by the new changes and pre-existing issues.
+4. **Reporting**: Provide a clear report of test results, including any failures and logs.
+
+## Guidelines
+
+- Focus on the "smallest relevant tests" to keep the loop fast.
+- If tests fail, provide enough context (logs, error messages) for the Implementer agent to fix the issue.
+- Verify that the specific issue described in the task is actually resolved.


### PR DESCRIPTION
## Summary
This PR introduces sub-agent delegation to the `devloop` plugin to reduce context growth in the main `devloop-runner` agent.

- **New Agents**:
  - `devloop-implementer`: Focused on codebase research and implementation.
  - `devloop-validator`: Focused on running tests and verifying fixes.
- **Runner Updates**:
  - `devloop-runner` now acts as an orchestrator, delegating heavy lifting to the new sub-agents using the `Task` tool.
  - This prevents the main agent's context from ballooning during long implementation or review cycles.

## Test plan
- [x] Create `devloop-implementer.md`
- [x] Create `devloop-validator.md`
- [x] Update `devloop-runner.md` to use the `Task` tool.
- [ ] Verify functionality with a sample devloop task.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive documentation for new specialized agents (Implementer and Validator) with defined responsibilities, tools, and operational guidelines.

* **Refactor**
  * Modified the devloop runner workflow to delegate implementation and validation tasks to specialized agents instead of direct execution, while maintaining existing PR and commit processes.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->