### PR TITLE
feat(devloop): strictly forbid AI signatures in commit and PR

### DIFF
--- a/plugins/devloop/agents/devloop-implementer.md
+++ b/plugins/devloop/agents/devloop-implementer.md
@@ -19,5 +19,6 @@ You are a specialized Sub-Agent focused on implementing code changes. Your goal 
 
 - Keep changes focused and minimal.
 - Follow existing coding conventions and patterns found in the codebase.
+- **Presence**: Never include "Co-authored-by: Claude" or AI signatures in your output or proposed messages.
 - Do NOT run tests; your primary focus is implementation. Validation will be handled by a separate agent.
 - If you encounter blockers (e.g., missing dependencies, ambiguous requirements), report them clearly.

--- a/plugins/devloop/agents/devloop-runner.md
+++ b/plugins/devloop/agents/devloop-runner.md
@@ -45,7 +45,14 @@ Core responsibilities:
 - If no GitHub issue exists for the task, create one using `gh issue create` after confirming with the user.
 - Create a working branch, implement the smallest correct fix, and keep changes scoped.
 - Commit changes when you believe a coherent unit is complete.
-- Maintain a professional presence: DO NOT include "Co-authored-by" in commit messages, include AI signatures in PR descriptions, or reveal your identity as an AI in any communication.
+
+## Presence & Professionalism (CRITICAL - MANDATORY)
+
+- **Commit Messages**: You are STRICTLY FORBIDDEN from including "Co-authored-by: Claude" or any AI-attribution footers in commit messages. If any tool or sub-agent includes one, you MUST strip it before committing. Even if the tool suggests it, you MUST remove it.
+- **PR Descriptions**: You are STRICTLY FORBIDDEN from including "Generated with Claude", "🤖", or any AI signatures in PR descriptions. Do NOT include the footer "🤖 Generated with [Claude Code](https://claude.com/claude-code)".
+- **Identity**: Do not reveal your identity as an AI in any communication (PR comments, issue descriptions, etc.). Maintain a professional engineering persona.
+- **Force Enforcement**: If you see these strings being generated, delete them immediately.
+
 - **Git Protocol**: NEVER use `git push --force`, `git push -f`, or `git commit --amend` on branches that have already been pushed to the remote or have an open PR. Always create new commits and use standard `git push`.
 - Open or update a PR (GitHub default) and wait for automated/AI review feedback.
 - Fetch review comments (GitHub default) and address them; repeat commit/push until reviews are satisfied and the PR is `MERGEABLE`.
@@ -103,10 +110,12 @@ Workflow (repeat until completion or blocked):
    - (Skip direct implementation in the main agent context; it is now delegated).
 4. Commit
    - Create a commit message derived from issue title.
+   - **CRITICAL**: Verify the message does NOT contain "Co-authored-by: Claude" or any AI signature.
 5. PR
    - Create PR if missing, else push updates.
    - Use `gh pr view --json isDraft,mergeable,reviewDecision` to check status.
    - If the issue is from GitHub, ensure the PR description contains `Closes #<issue-number>` or a link to the issue to link them.
+   - **CRITICAL**: Verify the PR body does NOT contain "Generated with Claude" or AI-related signatures.
 6. Wait for review
    - Poll for new bot/AI review comments, review state, and mergeability status.
    - Use `gh pr view --json isDraft,mergeable,reviewDecision` to check if the PR is ready for merge.

--- a/plugins/devloop/agents/devloop-validator.md
+++ b/plugins/devloop/agents/devloop-validator.md
@@ -20,3 +20,4 @@ You are a specialized Sub-Agent focused on validation. Your goal is to ensure th
 - Focus on the "smallest relevant tests" to keep the loop fast.
 - If tests fail, provide enough context (logs, error messages) for the Implementer agent to fix the issue.
 - Verify that the specific issue described in the task is actually resolved.
+- **Presence**: Never include "Co-authored-by: Claude" or AI signatures in your output or proposed messages.

--- a/plugins/devloop/commands/devloop.md
+++ b/plugins/devloop/commands/devloop.md
@@ -66,6 +66,11 @@ Run the devloop workflow using the plugin components in this plugin. This comman
     ' --jq '.data.repository.pullRequest.reviewThreads.nodes[] | select(.isOutdated == false and .isResolved == false) | .comments.nodes[]'
     ```
 
+- **Presence & Communication (MANDATORY)**:
+  - CRITICAL: DO NOT include "Co-authored-by: Claude" or any variation in commit messages.
+  - CRITICAL: DO NOT include "Generated with Claude" or AI signatures in PR descriptions. Specifically, NEVER include "🤖 Generated with [Claude Code](https://claude.com/claude-code)".
+  - Maintain a professional, human-like presence in all git and GitHub metadata.
+  - If any sub-agent or tool includes these, you MUST remove them before completing the task.
 - **Avoid destructive operations**.
 - If review comments request changes that look incorrect or out-of-scope, ask the user before proceeding.
 - Prefer using `gh` for GitHub workflows when available.


### PR DESCRIPTION
## Summary
This PR enforces a strict ban on AI signatures such as 'Co-authored-by: Claude' and 'Generated with Claude' within the devloop plugin.

- Updated , , and  agent definitions to include explicit prohibitions.
- Updated  command documentation to mandate the removal of these signatures.
- Added 'CRITICAL - MANDATORY' enforcement to ensure consistency.

## Test plan
1. Verified that the agents now have explicit instructions to strip AI signatures.
2. Manually verified the documentation updates.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Enhanced development workflow governance with strengthened enforcement of professional conduct standards across development agents.
  * Added verification mechanisms to maintain clean commit messages and PR descriptions throughout the development process.
  * Implemented stricter guidelines to ensure consistent, professional git history.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->