### PR TITLE
feat(devloop): support Feishu/Lark Project issue workflow

### DIFF
--- a/plugins/devloop/agents/devloop-runner.md
+++ b/plugins/devloop/agents/devloop-runner.md
@@ -43,8 +43,14 @@ Core responsibilities:
 
 - Determine issue source (GitHub via `gh`, Feishu/Lark Project issue URL/identifier, or local text/file).
 - If a Feishu/Lark Project issue is provided:
-  - Fetch its title/body (and other useful metadata) via the Feishu/Lark Project OpenAPI, using locally configured credentials.
-  - Use that as the task description for the rest of the workflow.
+  - Parse `base_url`, `project_key`, `work_item_type_key`, `work_item_id` from the URL/identifier.
+    - Common URL format: `https://project.feishu.cn/<project_key>/<work_item_type>/detail/<work_item_id>` (example: `.../story/detail/123`).
+  - Auth via Project OpenAPI headers:
+    - `X-PLUGIN-TOKEN`: plugin token (p-...) obtained from `POST {base_url}/open_api/authen/plugin_token` using `{ "plugin_id": "...", "plugin_secret": "..." }`.
+    - `X-USER-KEY`: optional; some endpoints require user context/permission.
+  - Fetch issue/work-item details (title/body):
+    - `POST {base_url}/open_api/{project_key}/work_item/{work_item_type_key}/query` with `{ "work_item_ids": [<work_item_id>] }`.
+    - Use returned JSON fields to derive a concise title + body for the devloop task description.
 - If no GitHub issue exists for the task, create one using `gh issue create` after confirming with the user.
 - Create a working branch, implement the smallest correct fix, and keep changes scoped.
 - Commit changes when you believe a coherent unit is complete.
@@ -91,8 +97,10 @@ Workflow (repeat until completion or blocked):
 1. Gather inputs
    - Identify repo/root and issue identifier.
    - If the argument looks like a Feishu/Lark Project issue URL/identifier:
-     - Fetch the issue title/body via the Feishu/Lark Project OpenAPI using locally configured credentials.
-     - Use the fetched content as the task description for the rest of the workflow.
+     - Parse `base_url`, `project_key`, `work_item_type_key`, `work_item_id`.
+     - Obtain `X-PLUGIN-TOKEN` by calling `POST {base_url}/open_api/authen/plugin_token` with `plugin_id`/`plugin_secret` (from local env/secrets).
+     - Fetch work-item details via `POST {base_url}/open_api/{project_key}/work_item/{work_item_type_key}/query` with `{ "work_item_ids": [<work_item_id>] }`.
+     - Use the fetched title/body as the task description for the rest of the workflow.
      - (Optional) Ask the user whether to also create a mirror GitHub issue to track the work.
    - If NO issue identifier is provided but the task is described in text or a file:
      - Prompt the user via `AskUserQuestion` to confirm if a GitHub issue should be created to track the work. This is HIGHLY RECOMMENDED for a complete workflow.

--- a/plugins/devloop/commands/devloop.md
+++ b/plugins/devloop/commands/devloop.md
@@ -25,7 +25,11 @@ Run the devloop workflow using the plugin components in this plugin. This comman
 1. **Determine the issue source**:
 
    - If the argument looks like a GitHub URL or issue/PR number, use `gh` to fetch title/body, labels, repo, and existing PR linkage.
-   - If the argument looks like a Feishu/Lark Project issue URL or identifier, fetch the issue title/body via the Feishu/Lark Project API (requires local environment credentials) and use that as the task description.
+   - If the argument looks like a Feishu/Lark Project issue URL or identifier, fetch the issue title/body via Feishu Project OpenAPI (requires local credentials) and use that as the task description.
+     - Typical issue URL pattern (seen in the wild): `https://project.feishu.cn/<project_key>/<work_item_type>/detail/<work_item_id>` (e.g. `.../story/detail/123`).
+     - Auth (Project OpenAPI): send `X-PLUGIN-TOKEN` (and sometimes `X-USER-KEY`) headers.
+       - Get a plugin token (example): `POST {base_url}/open_api/authen/plugin_token` with JSON `{ "plugin_id": "...", "plugin_secret": "..." }`, then use response `data.token` as `X-PLUGIN-TOKEN`.
+     - Fetch work item details (example): `POST {base_url}/open_api/{project_key}/work_item/{work_item_type_key}/query` with JSON `{ "work_item_ids": [<work_item_id>] }`.
    - When NO argument is provided, or if starting on a non-base branch, use `gh pr list --head $(git branch --show-current) --json number,url,title,body` to check for an existing PR associated with the current branch.
    - Should NO argument be provided and NO existing PR is found, the agent will prompt for a task description or offer to create a new issue.
    - If the argument looks like a local file path, read it and treat it as the issue/task description.


### PR DESCRIPTION
## Summary
- Teach /devloop to recognize Feishu/Lark Project issue URLs/identifiers as a first-class issue source.
- Document fetching issue title/body via Feishu/Lark Project OpenAPI (using local credentials) and using it as the task description.

## Notes
- This change updates devloop workflow instructions (command + runner agent); it does not add an API client implementation.

Closes #21

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Feishu/Lark Project as an alternative issue source alongside GitHub.
  * Users can supply Feishu/Lark Project issue URLs/identifiers to automatically fetch and populate task titles and descriptions.
  * Optionally create a mirrored GitHub issue to track work originating from Feishu/Lark.
  * Command usage updated to accept and route Feishu/Lark inputs during task creation.

* **Documentation**
  * Updated guidance on using Feishu/Lark inputs and the related workflow.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->